### PR TITLE
add step to clear openvidu generated sessionId

### DIFF
--- a/KITE-OpenVidu-Test/js/pages/CallPage.js
+++ b/KITE-OpenVidu-Test/js/pages/CallPage.js
@@ -14,6 +14,7 @@ class CallPage extends OpenViduBasePage {
   async joinSession(sessionId) {
     // const sessionId = session + stepInfo.uuid;
     let room = await this.driver.findElement(roomInput);
+    await room.clear();
     await room.sendKeys(sessionId);
     await room.sendKeys(Key.ENTER);
     await this.driver.wait(until.elementLocated(joinButton) || 6000);


### PR DESCRIPTION
The latest versions of openvidu-call have autogenerated sessionId's, 
this  will add a step on test script to delete that before entering the one passed to it